### PR TITLE
Restore Cinnamon settings header border

### DIFF
--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -4012,6 +4012,10 @@ NemoWindow EelEditableLabel.entry {
 .nemo-window .path-bar {
   -gtk-icon-style: regular; }
 
+.cs-header {
+  border-bottom: 1px solid #171819;
+  padding: 4px 8px; }
+
 .open-document-selector-treeview.view, iconview.open-document-selector-treeview {
   padding: 3px 6px 3px 6px;
   border-color: #2B2B2C; }

--- a/common/gtk-3.0/3.20/gtk-light.css
+++ b/common/gtk-3.0/3.20/gtk-light.css
@@ -4023,6 +4023,10 @@ NemoWindow EelEditableLabel.entry {
 .nemo-window .path-bar {
   -gtk-icon-style: regular; }
 
+.cs-header {
+  border-bottom: 1px solid #b9b9b9;
+  padding: 4px 8px; }
+
 .open-document-selector-treeview.view, iconview.open-document-selector-treeview {
   padding: 3px 6px 3px 6px;
   border-color: #ffffff; }

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -4026,6 +4026,10 @@ NemoWindow EelEditableLabel.entry {
 .nemo-window .path-bar {
   -gtk-icon-style: regular; }
 
+.cs-header {
+  border-bottom: 1px solid #b9b9b9;
+  padding: 4px 8px; }
+
 .open-document-selector-treeview.view, iconview.open-document-selector-treeview {
   padding: 3px 6px 3px 6px;
   border-color: #ffffff; }

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -114,6 +114,15 @@ $disk_space_free: darken($bg_color, 3%);
 }
 
 //
+// Cinnamon Settings
+//
+
+.cs-header {
+  border-bottom: 1px solid $borders_color;
+  padding: 4px 8px;
+}
+
+//
 // Gedit
 //
 .open-document-selector-treeview.view {


### PR DESCRIPTION
Since Cinnamon 3.8, settings header border is no longer hardcoded and is missing in the theme, so add it.